### PR TITLE
Sonar improvements

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filing/Application.java
+++ b/src/main/java/uk/gov/companieshouse/filing/Application.java
@@ -37,7 +37,7 @@ public class Application implements CommandLineRunner {
     private long sleepTime = 1000; // ms
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication.run(Application.class, new String[0]);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/filing/model/Address.java
+++ b/src/main/java/uk/gov/companieshouse/filing/model/Address.java
@@ -32,9 +32,6 @@ public class Address {
     
     @JsonProperty("region")
     private String region;
-
-    public Address() {
-    }
     
     public String getAddressLine1() {
         return addressLine1;

--- a/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessingException.java
+++ b/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessingException.java
@@ -6,29 +6,25 @@ public class FilingProcessingException extends Exception {
 
     private static final long serialVersionUID = 2081072809279727919L;
 
-    private FilingReceived filingReceived;
+    private final FilingReceived filingReceived;
 
     public FilingProcessingException(FilingReceived filingReceived) {
         super();
-        setFilingReceived(filingReceived);
+        this.filingReceived = filingReceived;
     }
 
     public FilingProcessingException(String message, FilingReceived filingReceived, Throwable cause) {
         super(message, cause);
-        setFilingReceived(filingReceived);
+        this.filingReceived = filingReceived;
     }
 
     public FilingProcessingException(String message, FilingReceived filingReceived) {
         super(message);
-        setFilingReceived(filingReceived);
+        this.filingReceived = filingReceived;
     }
     
     public FilingProcessingException(FilingReceived filingReceived, Throwable cause) {
         super(cause);
-        setFilingReceived(filingReceived);
-    }
-   
-    public void setFilingReceived(FilingReceived filingReceived) {
         this.filingReceived = filingReceived;
     }
 


### PR DESCRIPTION
Fix 2 Sonar smells and 1 security hotspot:
- Remove empty constructor
- Exception classes should be immutable
- Make sure that command line arguments are used safely.