### PR TITLE
Add unit test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,9 @@
     </parent>
 
     <properties>
-        <!-- Java -->
         <java.version>1.8</java.version>
-
-        <!-- Dependency Versions -->
+        <junit-jupiter-engine.version>5.6.0</junit-jupiter-engine.version>
+        <mockito-junit-jupiter.version>3.2.4</mockito-junit-jupiter.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <kafka-models.version>1.0.12</kafka-models.version>
         <structured-logging.version>1.9.3</structured-logging.version>
@@ -52,6 +51,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessorImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessorImpl.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.filing.Application;
@@ -36,6 +37,7 @@ public class FilingProcessorImpl implements FilingProcessor {
     private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
     private final SimpleDateFormat sdk = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.UK);
     
+    @Autowired
     private DateService dateService;
     
     @Override

--- a/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessorImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/processor/FilingProcessorImpl.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.filing.processor;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -21,6 +20,7 @@ import uk.gov.companieshouse.filing.processed.ResponseRecord;
 import uk.gov.companieshouse.filing.processed.SubmissionRecord;
 import uk.gov.companieshouse.filing.received.FilingReceived;
 import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filing.util.DateService;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -35,6 +35,8 @@ public class FilingProcessorImpl implements FilingProcessor {
     private static final String CH_POSTCODE_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
     private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
     private final SimpleDateFormat sdk = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.UK);
+    
+    private DateService dateService;
     
     @Override
     public FilingProcessed process(FilingReceived filingReceived) throws FilingProcessingException {
@@ -63,7 +65,7 @@ public class FilingProcessorImpl implements FilingProcessor {
         ResponseRecord response = new ResponseRecord();
         response.setCompanyName(filingReceived.getSubmission().getCompanyName());
         response.setCompanyNumber(filingReceived.getSubmission().getCompanyNumber());
-        String formattedDate = sdk.format(new Date());
+        String formattedDate = sdk.format(dateService.now());
         response.setDateOfCreation(formattedDate); // now ?
         response.setProcessedAt(formattedDate); // now ?
         try {

--- a/src/main/java/uk/gov/companieshouse/filing/reader/FilingReaderImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/reader/FilingReaderImpl.java
@@ -3,7 +3,9 @@ package uk.gov.companieshouse.filing.reader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import uk.gov.companieshouse.filing.Application;
 import uk.gov.companieshouse.filing.received.FilingReceived;
+import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.consumer.CHKafkaConsumerGroup;
 import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
 import uk.gov.companieshouse.kafka.deserialization.DeserializerFactory;
@@ -25,21 +28,21 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 @Component
 public class FilingReaderImpl implements FilingReader {
     private static final Logger LOG = LoggerFactory.getLogger(Application.APPLICATION_NAME);
-    
+
     @Autowired
     private String applicationName;
-    
+
     @Value("${kafka.broker.address}")
     private String brokerAddress;
-    
+
     @Value("${kafka.consumer.topic}")
     private String topicName;
 
     @Value("${kafka.consumer.pollTimeout:100}")
     private long pollTimeout = 100;
-    
-    private CHKafkaConsumerGroup consumer;
-    
+
+    private CHConsumer consumer;
+
     @Autowired
     private DeserializerFactory deserializerFactory;
 
@@ -54,7 +57,7 @@ public class FilingReaderImpl implements FilingReader {
         consumer = new CHKafkaConsumerGroup(config);
         consumer.connect();
     }
-    
+
     @PreDestroy
     public void close() {
         consumer.close();
@@ -67,13 +70,16 @@ public class FilingReaderImpl implements FilingReader {
             try {
                 receivedList.add(deserialise(msg));
             } catch (Exception e) {
-                LOG.error("Failed to read message from queue", e);
+                Map<String, Object> data = new HashMap<>();
+                data.put("message", msg.getValue() == null ? "" : msg.getValue().toString());
+                LOG.error("Failed to read message from queue", e, data);
             }
         }
         return receivedList;
     }
-    
+
     private FilingReceived deserialise(Message msg) throws DeserializationException {
-        return deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class).fromBinary(msg, FilingReceived.getClassSchema());
+        return deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class).fromBinary(msg,
+                FilingReceived.getClassSchema());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filing/reader/FilingReaderImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/reader/FilingReaderImpl.java
@@ -71,7 +71,7 @@ public class FilingReaderImpl implements FilingReader {
                 receivedList.add(deserialise(msg));
             } catch (Exception e) {
                 Map<String, Object> data = new HashMap<>();
-                data.put("message", msg.getValue() == null ? "" : msg.getValue().toString());
+                data.put("message", msg.getValue() == null ? "" : new String(msg.getValue()));
                 LOG.error("Failed to read message from queue", e, data);
             }
         }

--- a/src/main/java/uk/gov/companieshouse/filing/util/DateService.java
+++ b/src/main/java/uk/gov/companieshouse/filing/util/DateService.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.filing.util;
+
+import java.util.Date;
+
+public interface DateService {
+
+    Date now();
+
+}

--- a/src/main/java/uk/gov/companieshouse/filing/util/DateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/util/DateServiceImpl.java
@@ -2,6 +2,9 @@ package uk.gov.companieshouse.filing.util;
 
 import java.util.Date;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class DateServiceImpl implements DateService {
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/filing/util/DateServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filing/util/DateServiceImpl.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.filing.util;
+
+import java.util.Date;
+
+public class DateServiceImpl implements DateService {
+
+    @Override
+    public Date now() {
+        return new Date();
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filing/ApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/filing/ApplicationTest.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.filing;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.filing.processed.FilingProcessed;
+import uk.gov.companieshouse.filing.processor.FilingProcessingException;
+import uk.gov.companieshouse.filing.processor.FilingProcessor;
+import uk.gov.companieshouse.filing.reader.FilingReader;
+import uk.gov.companieshouse.filing.received.FilingReceived;
+import uk.gov.companieshouse.filing.writer.FilingWriter;
+import uk.gov.companieshouse.filing.writer.FilingWriterException;
+
+@ExtendWith(MockitoExtension.class)
+public class ApplicationTest {
+
+    @InjectMocks
+    private Application app;
+
+    @Mock
+    private FilingReader reader;
+
+    @Mock
+    private FilingWriter writer;
+
+    @Mock
+    private FilingProcessor processor;
+
+    @Test
+    public void processFilingsNoElements() {
+        Collection<FilingReceived> filingsReceived = Collections.emptyList();
+
+        when(reader.read()).thenReturn(filingsReceived);
+
+        app.processFilings();
+
+        verifyNoInteractions(writer, processor);
+    }
+
+    @Test
+    public void processFilings() throws Exception {
+        FilingReceived received1 = createFilingReceived("1");
+        FilingReceived received2 = createFilingReceived("2");
+        Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
+
+        when(reader.read()).thenReturn(filingsReceived);
+
+        FilingProcessed processed1 = createFilingProcessed(received1.getApplicationId());
+        FilingProcessed processed2 = createFilingProcessed(received2.getApplicationId());
+
+        when(processor.process(received1)).thenReturn(processed1);
+        when(processor.process(received2)).thenReturn(processed2);
+
+        app.processFilings();
+
+        verify(writer).write(processed1);
+        verify(writer).write(processed2);
+        verifyNoMoreInteractions(writer);
+    }
+
+    @Test
+    public void processFilingsProcessingException() throws Exception {
+        FilingReceived received1 = createFilingReceived("1");
+        FilingReceived received2 = createFilingReceived("2");
+        Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
+
+        when(reader.read()).thenReturn(filingsReceived);
+
+        FilingProcessed processed2 = createFilingProcessed(received2.getApplicationId());
+
+        when(processor.process(received1)).thenThrow(FilingProcessingException.class);
+        when(processor.process(received2)).thenReturn(processed2);
+
+        app.processFilings();
+
+        // Verify it still writes subsequent filings
+        verify(writer).write(processed2);
+        verifyNoMoreInteractions(writer);
+    }
+    
+    @Test
+    public void processFilingsWritingException() throws Exception {
+        FilingReceived received1 = createFilingReceived("1");
+        FilingReceived received2 = createFilingReceived("2");
+        Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
+
+        when(reader.read()).thenReturn(filingsReceived);
+
+        FilingProcessed processed1 = createFilingProcessed(received1.getApplicationId());
+        FilingProcessed processed2 = createFilingProcessed(received2.getApplicationId());
+
+        when(processor.process(received1)).thenReturn(processed1);
+        when(processor.process(received2)).thenReturn(processed2);
+        
+        when(writer.write(processed1)).thenThrow(FilingWriterException.class);
+
+        app.processFilings();
+
+        // Verify it still writes subsequent filings
+        verify(writer).write(processed2);
+        verifyNoMoreInteractions(writer);
+    }
+
+    private FilingReceived createFilingReceived(String applicationId) {
+        uk.gov.companieshouse.filing.received.SubmissionRecord submission = new uk.gov.companieshouse.filing.received.SubmissionRecord();
+        submission.setTransactionId("T" + applicationId);
+
+        FilingReceived received = new FilingReceived();
+        received.setSubmission(submission);
+        received.setApplicationId(applicationId);
+        return received;
+    }
+    
+    private FilingProcessed createFilingProcessed(String applicationId) {
+        uk.gov.companieshouse.filing.processed.SubmissionRecord submission = new uk.gov.companieshouse.filing.processed.SubmissionRecord();
+        submission.setTransactionId("T" + applicationId);
+
+        FilingProcessed processed = new FilingProcessed();
+        processed.setSubmission(submission);
+        processed.setApplicationId(applicationId);
+        return processed;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filing/processor/FilingProcessorImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filing/processor/FilingProcessorImplTest.java
@@ -1,0 +1,136 @@
+package uk.gov.companieshouse.filing.processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.filing.processed.FilingProcessed;
+import uk.gov.companieshouse.filing.received.FilingReceived;
+import uk.gov.companieshouse.filing.received.PresenterRecord;
+import uk.gov.companieshouse.filing.received.SubmissionRecord;
+import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filing.util.DateService;
+
+@ExtendWith(MockitoExtension.class)
+public class FilingProcessorImplTest {
+
+    @InjectMocks
+    private FilingProcessorImpl processor;
+    
+    @Mock
+    private DateService dateService;
+    
+    @Test
+    public void processAcceptedAddressWithoutPostCode() throws Exception {
+        Date now = new Date();
+        when(dateService.now()).thenReturn(now);
+        final String nowString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(now);
+
+        Transaction transaction = new Transaction();
+        transaction.setData("{}");
+        FilingReceived received = createFilingReceived(transaction);
+
+        FilingProcessed processed = processor.process(received);
+        
+        assertEquals(received.getApplicationId(), processed.getApplicationId());
+        assertEquals(1, processed.getAttempt());
+        assertEquals(received.getChannelId(), processed.getChannelId());
+        assertEquals(received.getPresenter().getLanguage(), processed.getPresenter().getLanguage());
+        assertEquals(received.getPresenter().getUserId(), processed.getPresenter().getUserId());
+        assertEquals(received.getSubmission().getTransactionId(), processed.getSubmission().getTransactionId());
+        assertEquals(received.getSubmission().getCompanyName(), processed.getResponse().getCompanyName());
+        assertEquals(received.getSubmission().getCompanyNumber(), processed.getResponse().getCompanyNumber());
+        assertEquals(nowString, processed.getResponse().getProcessedAt());
+        assertEquals(nowString, processed.getResponse().getDateOfCreation());
+        assertEquals("accepted", processed.getResponse().getStatus());
+        assertNull(processed.getResponse().getReject());
+    }
+
+    @Test
+    public void processAcceptedAddressNotChPostCode() throws Exception {
+        Date now = new Date();
+        when(dateService.now()).thenReturn(now);
+        final String nowString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(now);
+
+        Transaction transaction = new Transaction();
+        transaction.setData("{\"postal_code\":\"NR14 3UZ\"}");
+        FilingReceived received = createFilingReceived(transaction);
+
+        FilingProcessed processed = processor.process(received);
+        
+        assertEquals(received.getApplicationId(), processed.getApplicationId());
+        assertEquals(1, processed.getAttempt());
+        assertEquals(received.getChannelId(), processed.getChannelId());
+        assertEquals(received.getPresenter().getLanguage(), processed.getPresenter().getLanguage());
+        assertEquals(received.getPresenter().getUserId(), processed.getPresenter().getUserId());
+        assertEquals(received.getSubmission().getTransactionId(), processed.getSubmission().getTransactionId());
+        assertEquals(received.getSubmission().getCompanyName(), processed.getResponse().getCompanyName());
+        assertEquals(received.getSubmission().getCompanyNumber(), processed.getResponse().getCompanyNumber());
+        assertEquals(nowString, processed.getResponse().getProcessedAt());
+        assertEquals(nowString, processed.getResponse().getDateOfCreation());
+        assertEquals("accepted", processed.getResponse().getStatus());
+        assertNull(processed.getResponse().getReject());
+    }
+    
+    @Test
+    public void processRejectedAddressChPostCode() throws Exception {
+        Date now = new Date();
+        when(dateService.now()).thenReturn(now);
+        final String nowString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(now);
+
+        Transaction transaction = new Transaction();
+        transaction.setData("{\"postal_code\":\"CF14 3UZ\"}");
+        FilingReceived received = createFilingReceived(transaction);
+
+        FilingProcessed processed = processor.process(received);
+        
+        assertEquals(received.getApplicationId(), processed.getApplicationId());
+        assertEquals(1, processed.getAttempt());
+        assertEquals(received.getChannelId(), processed.getChannelId());
+        assertEquals(received.getPresenter().getLanguage(), processed.getPresenter().getLanguage());
+        assertEquals(received.getPresenter().getUserId(), processed.getPresenter().getUserId());
+        assertEquals(received.getSubmission().getTransactionId(), processed.getSubmission().getTransactionId());
+        assertEquals(received.getSubmission().getCompanyName(), processed.getResponse().getCompanyName());
+        assertEquals(received.getSubmission().getCompanyNumber(), processed.getResponse().getCompanyNumber());
+        assertEquals(nowString, processed.getResponse().getProcessedAt());
+        assertEquals(nowString, processed.getResponse().getDateOfCreation());
+        assertEquals("rejected", processed.getResponse().getStatus());
+        assertNotNull(processed.getResponse().getReject());
+        assertTrue(processed.getResponse().getReject().getReasonsEnglish().contains("The postcode you have supplied cannot be Companies House postcode"));
+        assertTrue(processed.getResponse().getReject().getReasonsWelsh().contains("Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau"));
+    }
+    
+    @Test
+    public void processInvalidTransactionData() throws Exception {
+        Date now = new Date();
+        when(dateService.now()).thenReturn(now);
+        
+        Transaction transaction = new Transaction();
+        transaction.setData("invalid data");
+        FilingReceived received = createFilingReceived(transaction);
+
+        assertThrows(FilingProcessingException.class, () -> processor.process(received));
+    }
+
+    private FilingReceived createFilingReceived(Transaction... transactions) {
+        PresenterRecord presenter = PresenterRecord.newBuilder().setLanguage("en").setUserId("user")
+                .setForename("forename").setSurname("surname").build();
+        SubmissionRecord submission = SubmissionRecord.newBuilder().setCompanyName("Company").setCompanyNumber("123456")
+                .setTransactionId("1234-5678").setReceivedAt("2020-01-20T15:22:24Z").build();
+        return FilingReceived.newBuilder().setApplicationId("AppId").setChannelId("chs").setAttempt(1)
+                .setPresenter(presenter).setSubmission(submission).setItems(Arrays.asList(transactions)).build();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filing/reader/FilingReaderImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filing/reader/FilingReaderImplTest.java
@@ -1,0 +1,106 @@
+package uk.gov.companieshouse.filing.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.filing.received.FilingReceived;
+import uk.gov.companieshouse.filing.received.SubmissionRecord;
+import uk.gov.companieshouse.kafka.consumer.CHConsumer;
+import uk.gov.companieshouse.kafka.deserialization.AvroDeserializer;
+import uk.gov.companieshouse.kafka.deserialization.DeserializerFactory;
+import uk.gov.companieshouse.kafka.exceptions.DeserializationException;
+import uk.gov.companieshouse.kafka.message.Message;
+
+@ExtendWith(MockitoExtension.class)
+public class FilingReaderImplTest {
+
+    @InjectMocks
+    private FilingReaderImpl reader;
+
+    @Mock
+    private CHConsumer consumer;
+
+    @Mock
+    private DeserializerFactory deserializerFactory;
+
+    @Mock
+    private AvroDeserializer<FilingReceived> deserializer;
+
+    @Test
+    public void readNoMessage() {
+        List<Message> messages = Collections.emptyList();
+        when(consumer.consume()).thenReturn(messages);
+
+        Collection<FilingReceived> result = reader.read();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void readValidMessages() throws Exception {
+        when(deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class)).thenReturn(deserializer);
+
+        List<Message> messages = new ArrayList<>();
+        Message message1 = new Message();
+        messages.add(message1);
+        Message message2 = new Message();
+        messages.add(message2);
+        when(consumer.consume()).thenReturn(messages);
+
+        FilingReceived filing1 = createFilingReceived("1");
+        FilingReceived filing2 = createFilingReceived("1");
+        when(deserializer.fromBinary(message1, FilingReceived.SCHEMA$)).thenReturn(filing1);
+        when(deserializer.fromBinary(message2, FilingReceived.SCHEMA$)).thenReturn(filing2);
+
+        Collection<FilingReceived> result = reader.read();
+
+        assertEquals(messages.size(), result.size());
+        assertTrue(result.contains(filing1));
+        assertTrue(result.contains(filing2));
+    }
+
+    @Test
+    public void readInvalidMessage() throws Exception {
+        when(deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class)).thenReturn(deserializer);
+
+        List<Message> messages = new ArrayList<>();
+        Message message1 = new Message();
+        messages.add(message1);
+        Message message2 = new Message();
+        messages.add(message2);
+        when(consumer.consume()).thenReturn(messages);
+
+        FilingReceived filing2 = createFilingReceived("1");
+        when(deserializer.fromBinary(message1, FilingReceived.SCHEMA$)).thenThrow(DeserializationException.class);
+        when(deserializer.fromBinary(message2, FilingReceived.SCHEMA$)).thenReturn(filing2);
+
+        Collection<FilingReceived> result = reader.read();
+
+        // assert it subsequent messages
+        assertEquals(1, result.size());
+        assertTrue(result.contains(filing2));
+    }
+
+    private FilingReceived createFilingReceived(String applicationId) {
+        SubmissionRecord submission = new SubmissionRecord();
+        submission.setTransactionId("T" + applicationId);
+
+        FilingReceived received = new FilingReceived();
+        received.setSubmission(submission);
+        received.setApplicationId(applicationId);
+        return received;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filing/writer/FilingWriterImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filing/writer/FilingWriterImplTest.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.filing.writer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FilingWriterImplTest {
+    
+    @InjectMocks
+    private FilingWriterImpl writer;
+    
+    @Test
+    public void write() throws Exception {
+        // TODO: implement unit test
+    }
+}


### PR DESCRIPTION
Add unit test coverage and rewrite filing processing using streams.

Note: no unit tests have been written for `FilingWriterImpl` as this is going to change from the existing proof of concept code (we'll call an API instead of writing to the Kafka queue)