### PR TITLE
Added additional CH postcodes for rejection in ROA filing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImpl.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class FilingProcessorImpl implements FilingProcessor {
     
     private static final String ACCEPTED = "accepted";
     private static final String REJECTED = "rejected";
-    private static final String CH_POSTCODE = "CF143UZ";
+    private static final List<String> CH_POSTCODE = Arrays.asList("CF143UZ","BT28BG","SW1H9EX","EH39FF");
     private static final String CH_POSTCODE_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
     private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
 
@@ -89,7 +90,7 @@ public class FilingProcessorImpl implements FilingProcessor {
         // check transaction for type in future development - not always going to be an address
         Address address = unmarshaller.unmarshallAddress(transaction.getData());
         return StringUtils.isNotEmpty(address.getPostalCode())
-                && address.getPostalCode().toUpperCase().replaceAll("\\s", "").equals(CH_POSTCODE);
+        		&& CH_POSTCODE.contains(address.getPostalCode().toUpperCase().replaceAll("\\s", ""));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImplTest.java
@@ -110,13 +110,31 @@ public class FilingProcessorImplTest {
     }
     
     @Test
-    public void processRejectedAddressChPostCode() throws Exception {
-        when(dateService.now()).thenReturn(INSTANT);
-
-        Transaction transaction = createTransaction("1");
+    public void processRejectedAddressChPostCodeWales() throws Exception {
+    	postCodeTest("CF14 3UZ");
+    }
+    
+    @Test
+    public void processRejectedAddressChPostCodeEngland() throws Exception {
+    	postCodeTest("SW1H 9EX");
+    }
+    
+    @Test
+    public void processRejectedAddressChPostCodeNorthernIreland() throws Exception {
+    	postCodeTest("BT2 8BG");
+    }
+    
+    @Test
+    public void processRejectedAddressChPostCodeScotland() throws Exception {
+    	postCodeTest("EH3 9FF");
+    }
+    
+    private void postCodeTest(String postCode) throws Exception {
+    	when(dateService.now()).thenReturn(INSTANT);
+    	Transaction transaction = createTransaction("1");
         FilingReceived received = createFilingReceived(transaction);
-
-        address.setPostalCode("CF14 3UZ");
+        
+        address.setPostalCode(postCode);
         when(unmarshaller.unmarshallAddress(transaction.getData())).thenReturn(address);
 
         List<FilingProcessed> processedResult = processor.process(received);


### PR DESCRIPTION
Additional CH postcodes (Northern Ireland, London, and Scotland) are now rejected in ROA filing.