### PR TITLE
Added additional CH postcodes for rejection in ROA filing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategy.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.filingmock.processor.strategy;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
@@ -23,7 +25,7 @@ public class RoaAcceptanceStrategy implements AcceptanceStrategy {
     private static final ObjectReader ADDRESS_READER = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readerFor(Address.class);
 
-    private static final String CH_POSTCODE = "CF143UZ";
+    private static final List<String> CH_POSTCODE = Arrays.asList("CF143UZ","BT28BG","SW1H9EX","EH39FF");
     private static final String CH_POSTCODE_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
     private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
 
@@ -60,7 +62,7 @@ public class RoaAcceptanceStrategy implements AcceptanceStrategy {
      */
     private boolean isValidAddress(Address address) {
         return StringUtils.isEmpty(address.getPostalCode())
-                || !address.getPostalCode().toUpperCase().replaceAll("\\s", "").equals(CH_POSTCODE);
+                || !CH_POSTCODE.contains(address.getPostalCode().toUpperCase().replaceAll("\\s", ""));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
@@ -42,16 +42,36 @@ public class RoaAcceptanceStrategyTest {
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
     }
-
+    
     @Test
-    void rejectChPostcode() throws Exception {
-        transaction.setData("{\"postal_code\":\"cf14  3UZ\"}");
+    public void rejectChPostcodeWales() throws Exception {
+        postCodeTest("CF14 3UZ");
+    }
+    
+    @Test
+    public void rejectChPostcodeEngland() throws Exception {
+        postCodeTest("SW1H 9EX");
+    }
+    
+    @Test
+    public void rejectChPostcodeNorthernIreland() throws Exception {
+        postCodeTest("BT2 8BG");
+    }
+    
+    @Test
+    public void rejectChPostcodeScotland() throws Exception {
+        postCodeTest("EH3 9FF");
+    }
+
+    private void postCodeTest(String postCode) throws Exception {
+        transaction.setData("{\"postal_code\":\""+ postCode +"\"}");
         FilingStatus filingStatus = strategy.accept(transaction);
         assertEquals(Status.REJECTED, filingStatus.getStatus());
         assertEquals(1, filingStatus.getRejection().getEnglishReasons().size());
         assertTrue(filingStatus.getRejection().getEnglishReasons().contains(ENGLISH_REJECT));
         assertEquals(1, filingStatus.getRejection().getWelshReasons().size());
         assertTrue(filingStatus.getRejection().getWelshReasons().contains(WELSH_REJECT));
+        
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
@@ -45,22 +45,22 @@ public class RoaAcceptanceStrategyTest {
     
     @Test
     public void rejectChPostcodeWales() throws Exception {
-        postCodeTest("CF14 3UZ");
+        postCodeTest("cf14 3UZ");
     }
     
     @Test
     public void rejectChPostcodeEngland() throws Exception {
-        postCodeTest("SW1H 9EX");
+        postCodeTest("SW1h  9EX");
     }
     
     @Test
     public void rejectChPostcodeNorthernIreland() throws Exception {
-        postCodeTest("BT2 8BG");
+        postCodeTest("BT2   8bg");
     }
     
     @Test
     public void rejectChPostcodeScotland() throws Exception {
-        postCodeTest("EH3 9FF");
+        postCodeTest("Eh39fF");
     }
 
     private void postCodeTest(String postCode) throws Exception {


### PR DESCRIPTION
Additional CH postcodes (Northern Ireland, London, and Scotland) are now rejected in ROA filing.
FA-228