### PR TITLE
Change to maven compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 artifact_name       := chips-filing-mock
-version             := "unversioned"
+version             := unversioned
 
 .PHONY: all
 all: clean build test package

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ artifact_name       := chips-filing-mock
 version             := "unversioned"
 
 .PHONY: all
-all: build
+all: clean build test package
 
 .PHONY: clean
 clean:
@@ -14,9 +14,7 @@ clean:
 
 .PHONY: build
 build:
-	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
-	mvn package -DskipTests=true
-	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
+	mvn compile
 
 .PHONY: test
 test: test-unit


### PR DESCRIPTION
The `build` target was actually packaging - this is already done in the `package` target (which copies the jar file to a different folder)
It now invokes `mvn compile` as it should do.
Also change the default target `all` to keep packaging (and now testing too)