### PR TITLE
ecct-566-strategy-for-rea

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/model/ConfirmationStatementFilingData.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/ConfirmationStatementFilingData.java
@@ -3,9 +3,9 @@ package uk.gov.companieshouse.filingmock.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Class to hold the data for RegisteredEmailAddress objects.
+ * Class to hold the data for a Confirmation Statement filing.
  */
-public class RegisteredEmailAddress {
+public class ConfirmationStatementFilingData {
 
     @JsonProperty("trading_on_market")
     private boolean tradingOnMarket;

--- a/src/main/java/uk/gov/companieshouse/filingmock/model/RegisteredEmailAddress.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/RegisteredEmailAddress.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.filingmock.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class to hold the data for RegisteredEmailAddress objects.
+ */
+public class RegisteredEmailAddress {
+
+    @JsonProperty("trading_on_market")
+    private boolean tradingOnMarket;
+
+    @JsonProperty("dtr5_ind")
+    private boolean dtr5Ind;
+
+    @JsonProperty("confirmation_statement_date")
+    private String confirmationStatementDate;
+
+    @JsonProperty("registered_email_address")
+    private String registeredEmailAddress;
+
+    public boolean isTradingOnMarket() {
+        return tradingOnMarket;
+    }
+
+    public void setTradingOnMarket(boolean tradingOnMarket) {
+        this.tradingOnMarket = tradingOnMarket;
+    }
+
+    public boolean isDtr5Ind() {
+        return dtr5Ind;
+    }
+
+    public void setDtr5Ind(boolean dtr5Ind) {
+        this.dtr5Ind = dtr5Ind;
+    }
+
+    public String getConfirmationStatementDate() {
+        return confirmationStatementDate;
+    }
+
+    public void setConfirmationStatementDate(String confirmationStatementDate) {
+        this.confirmationStatementDate = confirmationStatementDate;
+    }
+
+    public String getRegisteredEmailAddress() {
+        return registeredEmailAddress;
+    }
+
+    public void setRegisteredEmailAddress(String registeredEmailAddress) {
+        this.registeredEmailAddress = registeredEmailAddress;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.filingmock.model.FilingStatus;
 public class AcceptanceStrategyFactory {
 
     private static final AcceptanceStrategy ROA = new RoaAcceptanceStrategy();
+    private static final AcceptanceStrategy REA = new ReaAcceptanceStrategy();
     private static final AcceptanceStrategy INSOLVENCY = new InsolvencyAcceptanceStrategy();
     private static final AcceptanceStrategy CESSATION = new PscAcceptanceStrategy();
     private static final AcceptanceStrategy ALWAYS_ACCEPT = t -> new FilingStatus();
@@ -20,14 +21,15 @@ public class AcceptanceStrategyFactory {
 
         if ("registered-office-address".equals(submissionType)) {
             return ROA;
-            // There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency," and should use the same strategy
-        } else if (submissionType.contains("insolvency")) {
+        } else if ("registered-email-address".equals(submissionType)) {
+            return REA;
+        } else if (submissionType.contains("insolvency")) /* There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency," and should use the same strategy */ {
             return INSOLVENCY;
         } else if (submissionType.contains("cessation")) {
             return CESSATION;
         }
-        return ALWAYS_ACCEPT;
 
+        return ALWAYS_ACCEPT;
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategy.java
@@ -25,9 +25,9 @@ public class ReaAcceptanceStrategy implements AcceptanceStrategy {
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^.+@.+\\..+$");
 
-    // TODO get the email rejection texts
-    private static final String CH_REA_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
-    private static final String CH_REA_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
+    // FIXME rejection is not required for the REA strategy
+    private static final String CH_REA_ENGLISH_REJECT = "The email address is in an incorrect format. You must use the correct format, like name@example.com";
+    private static final String CH_REA_WELSH_REJECT = "Mae'r cyfeiriad e-bost mewn fformat anghywir. Rhaid i chi ddefnyddio'r fformat cywir, fel name@example.com";
 
     private static RegisteredEmailAddress getRegisteredEmailAddress(Transaction transaction) throws AcceptanceStrategyException {
         try {

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategy.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.filingmock.processor.strategy;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filingmock.model.FilingStatus;
+import uk.gov.companieshouse.filingmock.model.RegisteredEmailAddress;
+import uk.gov.companieshouse.filingmock.model.Status;
+
+/**
+ * Rejects the filing if the provided email does not match the Companies House regex (from registered-emil-address-api).
+ *
+ */
+@Component
+public class ReaAcceptanceStrategy implements AcceptanceStrategy {
+
+    private static final ObjectReader EMAIL_READER = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readerFor(RegisteredEmailAddress.class);
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^.+@.+\\..+$");
+
+    // TODO get the email rejection texts
+    private static final String CH_REA_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
+    private static final String CH_REA_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
+
+    private static RegisteredEmailAddress getRegisteredEmailAddress(Transaction transaction) throws AcceptanceStrategyException {
+        try {
+            return EMAIL_READER.readValue(transaction.getData());
+        } catch (IOException e) {
+            throw new AcceptanceStrategyException(e);
+        }
+    }
+
+    private static boolean isValidEmail(String email) {
+        if (email == null) {
+            return false;
+        }
+
+        return EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    @Override
+    public FilingStatus accept(Transaction transaction) throws AcceptanceStrategyException {
+        FilingStatus filingStatus = new FilingStatus();
+
+        RegisteredEmailAddress rea = getRegisteredEmailAddress(transaction);
+
+        if (!isValidEmail(rea.getRegisteredEmailAddress())) {
+            filingStatus.setStatus(Status.REJECTED);
+            filingStatus.addRejection(CH_REA_ENGLISH_REJECT, CH_REA_WELSH_REJECT);
+        }
+
+        return filingStatus;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.filingmock.processor.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filingmock.model.FilingStatus;
+import uk.gov.companieshouse.filingmock.model.Status;
+
+class ReaAcceptanceStrategyTest {
+
+    // TODO get the email rejection texts
+    private static final String ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
+    private static final String WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
+
+    private ReaAcceptanceStrategy strategy;
+
+    private Transaction transaction;
+
+    @BeforeEach
+    void setup() {
+        strategy = new ReaAcceptanceStrategy();
+        transaction = new Transaction();
+    }
+
+    @Test
+    void acceptValidEmail() throws Exception {
+        transaction.setData("{\"registered_email_address\":\"info@acme.com\"}");
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void rejectNoEmail() throws Exception {
+        emailFormatTest(null);
+    }
+
+    @Test
+    void rejectInvalidEmail() throws Exception {
+        emailFormatTest("info.acme.com");
+    }
+
+    private void emailFormatTest(String postCode) throws Exception {
+        transaction.setData("{\"registered_email_address\":\""+ postCode +"\"}");
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        assertEquals(Status.REJECTED, filingStatus.getStatus());
+        assertEquals(1, filingStatus.getRejection().getEnglishReasons().size());
+        assertTrue(filingStatus.getRejection().getEnglishReasons().contains(ENGLISH_REJECT));
+        assertEquals(1, filingStatus.getRejection().getWelshReasons().size());
+        assertTrue(filingStatus.getRejection().getWelshReasons().contains(WELSH_REJECT));
+    }
+
+    @Test
+    void throwsExceptionInvalidData() {
+        transaction.setData("invalid");
+
+        assertThrows(AcceptanceStrategyException.class, () -> strategy.accept(transaction));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.filingmock.processor.strategy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,61 @@ class ReaAcceptanceStrategyTest {
         // THEN
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void acceptValidEmailMissing() throws Exception {
+        // GIVEN
+        transaction.setData("{}");
+
+        // WHEN
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        // THEN
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void acceptValidEmailNull() throws Exception {
+        // GIVEN
+        transaction.setData("{\"registered_email_address\":null}");
+
+        // WHEN
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        // THEN
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void acceptValidEmailEmpty() throws Exception {
+        // GIVEN
+        transaction.setData("{\"registered_email_address\":\"\"}");
+
+        // WHEN
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        // THEN
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void rejectInvalidEmail() throws Exception {
+        // GIVEN
+        transaction.setData("{\"registered_email_address\":\"info@companieshouse.gov.uk\"}");
+
+        // WHEN
+        FilingStatus filingStatus = strategy.accept(transaction);
+
+        // THEN
+        assertEquals(Status.REJECTED, filingStatus.getStatus());
+        assertEquals(1, filingStatus.getRejection().getEnglishReasons().size());
+        assertTrue(filingStatus.getRejection().getEnglishReasons().contains(ReaAcceptanceStrategy.CH_EMAIL_ENGLISH_REJECT));
+        assertEquals(1, filingStatus.getRejection().getWelshReasons().size());
+        assertTrue(filingStatus.getRejection().getWelshReasons().contains(ReaAcceptanceStrategy.CH_EMAIL_WELSH_REJECT));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.filingmock.processor.strategy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,10 +12,6 @@ import uk.gov.companieshouse.filingmock.model.FilingStatus;
 import uk.gov.companieshouse.filingmock.model.Status;
 
 class ReaAcceptanceStrategyTest {
-
-    // FIXME rejection is not required for the REA strategy
-    private static final String ENGLISH_REJECT = "The email address is in an incorrect format. You must use the correct format, like name@example.com";
-    private static final String WELSH_REJECT = "Mae'r cyfeiriad e-bost mewn fformat anghywir. Rhaid i chi ddefnyddio'r fformat cywir, fel name@example.com";
 
     private ReaAcceptanceStrategy strategy;
 
@@ -30,38 +25,23 @@ class ReaAcceptanceStrategyTest {
 
     @Test
     void acceptValidEmail() throws Exception {
+        // GIVEN
         transaction.setData("{\"registered_email_address\":\"info@acme.com\"}");
+
+        // WHEN
         FilingStatus filingStatus = strategy.accept(transaction);
 
+        // THEN
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
     }
 
     @Test
-    void rejectNoEmail() throws Exception {
-        emailFormatTest(null);
-    }
-
-    @Test
-    void rejectInvalidEmail() throws Exception {
-        emailFormatTest("info.acme.com");
-    }
-
-    private void emailFormatTest(String postCode) throws Exception {
-        transaction.setData("{\"registered_email_address\":\""+ postCode +"\"}");
-        FilingStatus filingStatus = strategy.accept(transaction);
-
-        assertEquals(Status.REJECTED, filingStatus.getStatus());
-        assertEquals(1, filingStatus.getRejection().getEnglishReasons().size());
-        assertTrue(filingStatus.getRejection().getEnglishReasons().contains(ENGLISH_REJECT));
-        assertEquals(1, filingStatus.getRejection().getWelshReasons().size());
-        assertTrue(filingStatus.getRejection().getWelshReasons().contains(WELSH_REJECT));
-    }
-
-    @Test
     void throwsExceptionInvalidData() {
+        // GIVEN
         transaction.setData("invalid");
 
+        // WHEN & THEN
         assertThrows(AcceptanceStrategyException.class, () -> strategy.accept(transaction));
     }
 

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
@@ -14,9 +14,9 @@ import uk.gov.companieshouse.filingmock.model.Status;
 
 class ReaAcceptanceStrategyTest {
 
-    // TODO get the email rejection texts
-    private static final String ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
-    private static final String WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
+    // FIXME rejection is not required for the REA strategy
+    private static final String ENGLISH_REJECT = "The email address is in an incorrect format. You must use the correct format, like name@example.com";
+    private static final String WELSH_REJECT = "Mae'r cyfeiriad e-bost mewn fformat anghywir. Rhaid i chi ddefnyddio'r fformat cywir, fel name@example.com";
 
     private ReaAcceptanceStrategy strategy;
 


### PR DESCRIPTION
- A new strategy has been created for the registered email address filing with a rejection occurring when an email comprises @companieshouse.gov.uk
- JUnit tests cases were written
- No local testing in CHS Dev Env as more easy to test in the sandbox by the test team