### PR TITLE
Remove code smells

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/model/FilingProcessed.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/FilingProcessed.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.filingmock.model;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioners.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioners.java
@@ -1,9 +1,8 @@
 package uk.gov.companieshouse.filingmock.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Class to hold the data for the insolvency practitioners array of objects

--- a/src/test/java/uk/gov/companieshouse/filingmock/ApplicationTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/ApplicationTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.gov.companieshouse.filing.received.FilingReceived;
 import uk.gov.companieshouse.filing.received.SubmissionRecord;
-import uk.gov.companieshouse.filingmock.Application;
 import uk.gov.companieshouse.filingmock.model.FilingProcessed;
 import uk.gov.companieshouse.filingmock.processor.FilingProcessingException;
 import uk.gov.companieshouse.filingmock.processor.FilingProcessor;
@@ -26,7 +25,7 @@ import uk.gov.companieshouse.filingmock.writer.FilingWriter;
 import uk.gov.companieshouse.filingmock.writer.FilingWriterException;
 
 @ExtendWith(MockitoExtension.class)
-public class ApplicationTest {
+class ApplicationTest {
 
     @InjectMocks
     private Application app;
@@ -41,7 +40,7 @@ public class ApplicationTest {
     private FilingProcessor processor;
 
     @Test
-    public void processFilingsNoElements() {
+    void processFilingsNoElements() {
         Collection<FilingReceived> filingsReceived = Collections.emptyList();
 
         when(reader.read()).thenReturn(filingsReceived);
@@ -52,7 +51,7 @@ public class ApplicationTest {
     }
 
     @Test
-    public void processFilings() throws Exception {
+    void processFilings() throws Exception {
         FilingReceived received1 = createFilingReceived("1");
         FilingReceived received2 = createFilingReceived("2");
         Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
@@ -75,7 +74,7 @@ public class ApplicationTest {
     }
 
     @Test
-    public void processFilingsProcessingException() throws Exception {
+    void processFilingsProcessingException() throws Exception {
         FilingReceived received1 = createFilingReceived("1");
         FilingReceived received2 = createFilingReceived("2");
         Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
@@ -95,9 +94,9 @@ public class ApplicationTest {
         verify(writer).write(processed2);
         verifyNoMoreInteractions(writer);
     }
-    
+
     @Test
-    public void processFilingsWritingException() throws Exception {
+    void processFilingsWritingException() throws Exception {
         FilingReceived received1 = createFilingReceived("1");
         FilingReceived received2 = createFilingReceived("2");
         Collection<FilingReceived> filingsReceived = Arrays.asList(received1, received2);
@@ -130,7 +129,7 @@ public class ApplicationTest {
         received.setApplicationId(applicationId);
         return received;
     }
-    
+
     private FilingProcessed createFilingProcessed(String applicationId) {
         FilingProcessed processed = new FilingProcessed();
         processed.setTransactionId("T" + applicationId);

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/FilingProcessorImplTest.java
@@ -34,8 +34,8 @@ import uk.gov.companieshouse.filingmock.processor.strategy.AcceptanceStrategyExc
 import uk.gov.companieshouse.filingmock.util.DateService;
 
 @ExtendWith(MockitoExtension.class)
-public class FilingProcessorImplTest {
-    
+class FilingProcessorImplTest {
+
     private static final Instant INSTANT = ZonedDateTime.of(2020, 2, 17, 23, 9, 56, 250, ZoneOffset.UTC).toInstant();
 
     private static final String DATE_TIME_STRING = "2020-02-17T23:09:56Z";
@@ -51,22 +51,22 @@ public class FilingProcessorImplTest {
     private AcceptanceStrategy acceptanceStrategy;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(dateService.now()).thenReturn(INSTANT);
         doReturn(acceptanceStrategy).when(processor).getStrategy(any());
     }
-    
+
     @Test
-    public void processAcceptedFiling() throws Exception {
+    void processAcceptedFiling() throws Exception {
         Transaction transaction = createTransaction("1");
         FilingReceived received = createFilingReceived(transaction);
-        
+
         FilingStatus filingStatus = new FilingStatus();
         filingStatus.setStatus(Status.ACCEPTED);
         when(acceptanceStrategy.accept(transaction)).thenReturn(filingStatus);
 
         List<FilingProcessed> processedResult = processor.process(received);
-        
+
         assertEquals(1, processedResult.size());
         FilingProcessed processed = processedResult.get(0);
         assertEquals(received.getApplicationId(), processed.getApplicationId());
@@ -81,19 +81,19 @@ public class FilingProcessorImplTest {
         assertEquals(Status.ACCEPTED, processed.getStatus());
         assertNull(processed.getRejection());
     }
-    
+
     @Test
-    public void processRejectedFiling() throws Exception {
+    void processRejectedFiling() throws Exception {
         Transaction transaction = createTransaction("1");
         FilingReceived received = createFilingReceived(transaction);
-        
+
         FilingStatus filingStatus = new FilingStatus();
         filingStatus.setStatus(Status.REJECTED);
         filingStatus.addRejection("English rejection", "Gwrthod gymraeg");
         when(acceptanceStrategy.accept(transaction)).thenReturn(filingStatus);
 
         List<FilingProcessed> processedResult = processor.process(received);
-        
+
         assertEquals(1, processedResult.size());
         FilingProcessed processed = processedResult.get(0);
         assertEquals(received.getApplicationId(), processed.getApplicationId());
@@ -109,19 +109,19 @@ public class FilingProcessorImplTest {
         assertTrue(processed.getRejection().getEnglishReasons().contains("English rejection"));
         assertTrue(processed.getRejection().getWelshReasons().contains("Gwrthod gymraeg"));
     }
-    
+
     @Test
-    public void processInvalidTransactionData() throws Exception {
+    void processInvalidTransactionData() throws Exception {
         Transaction transaction = createTransaction("1");
         FilingReceived received = createFilingReceived(transaction);
 
         when(acceptanceStrategy.accept(transaction)).thenThrow(AcceptanceStrategyException.class);
-        
+
         assertThrows(FilingProcessingException.class, () -> processor.process(received));
     }
-    
+
     @Test
-    public void processFilingMultipleSubmissions() throws Exception {
+    void processFilingMultipleSubmissions() throws Exception {
         Transaction transaction1 = createTransaction("1");
         Transaction transaction2 = createTransaction("2");
         Transaction transaction3 = createTransaction("3");
@@ -160,7 +160,7 @@ public class FilingProcessorImplTest {
         return FilingReceived.newBuilder().setApplicationId("AppId").setChannelId("chs").setAttempt(1)
                 .setPresenter(presenter).setSubmission(submission).setItems(Arrays.asList(transactions)).build();
     }
-    
+
     private Transaction createTransaction(String id) {
         Transaction transaction = new Transaction();
         transaction.setData("data"+ id);

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
@@ -10,10 +10,10 @@ import uk.gov.companieshouse.filing.received.Transaction;
 import uk.gov.companieshouse.filingmock.model.FilingStatus;
 import uk.gov.companieshouse.filingmock.model.Status;
 
-public class AcceptanceStrategyFactoryTest {
+class AcceptanceStrategyFactoryTest {
 
     @Test
-    public void getRoaStrategy() {
+    void getRoaStrategy() {
         Transaction submission = new Transaction();
         submission.setKind("registered-office-address");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
@@ -21,7 +21,7 @@ public class AcceptanceStrategyFactoryTest {
     }
 
     @Test
-    public void getPscStrategy() {
+    void getPscStrategy() {
         Transaction submission = new Transaction();
         submission.setKind("cessation");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
@@ -29,7 +29,7 @@ public class AcceptanceStrategyFactoryTest {
     }
 
     @Test
-    public void get600Strategy() {
+    void get600Strategy() {
         Transaction submission = new Transaction();
         submission.setKind("insolvency#600");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
@@ -37,7 +37,7 @@ public class AcceptanceStrategyFactoryTest {
     }
     
     @Test
-    public void getDefaultStrategyUnknownType() throws Exception {
+    void getDefaultStrategyUnknownType() throws Exception {
         Transaction submission = new Transaction();
         submission.setKind("unknown-transaction-type");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
@@ -48,7 +48,7 @@ public class AcceptanceStrategyFactoryTest {
     }
     
     @Test
-    public void getDefaultStrategyMissingType() throws Exception {
+    void getDefaultStrategyMissingType() throws Exception {
         Transaction submission = new Transaction();
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
         // Default strategy is always accept

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategyTest.java
@@ -8,7 +8,7 @@ import uk.gov.companieshouse.filingmock.model.Status;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class InsolvencyAcceptanceStrategyTest {
+class InsolvencyAcceptanceStrategyTest {
 
     private static final String ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
     private static final String WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
@@ -40,22 +40,22 @@ public class InsolvencyAcceptanceStrategyTest {
     }
     
     @Test
-    public void rejectChPostcodeWales() throws Exception {
+    void rejectChPostcodeWales() throws Exception {
         postCodeTest("cf14 3UZ");
     }
     
     @Test
-    public void rejectChPostcodeEngland() throws Exception {
+    void rejectChPostcodeEngland() throws Exception {
         postCodeTest("Sw1H   9EX");
     }
     
     @Test
-    public void rejectChPostcodeNorthernIreland() throws Exception {
+    void rejectChPostcodeNorthernIreland() throws Exception {
         postCodeTest("BT2   8bg");
     }
     
     @Test
-    public void rejectChPostcodeScotland() throws Exception {
+    void rejectChPostcodeScotland() throws Exception {
         postCodeTest("Eh39fF");
     }
 

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/PscAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/PscAcceptanceStrategyTest.java
@@ -13,7 +13,8 @@ import java.time.LocalDate;
 import static org.junit.jupiter.api.Assertions.*;
 import static uk.gov.companieshouse.filingmock.processor.strategy.PscAcceptanceStrategy.INVALID_DATE_ENGLISH_REJECT;
 import static uk.gov.companieshouse.filingmock.processor.strategy.PscAcceptanceStrategy.INVALID_DATE_WELSH_REJECT;
-public class PscAcceptanceStrategyTest {
+
+class PscAcceptanceStrategyTest {
     private PscAcceptanceStrategy strategy;
 
     private Transaction transaction;
@@ -36,7 +37,7 @@ public class PscAcceptanceStrategyTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"2022-08-01", "2022-08-16"})
-    public void rejectCeasedOnDay(LocalDate ceasedOn) throws Exception {
+    void rejectCeasedOnDay(LocalDate ceasedOn) throws Exception {
         transaction.setData("{\"ceased_on\":\"" + ceasedOn + "\"}");
         FilingStatus filingStatus = strategy.accept(transaction);
         assertEquals(Status.REJECTED, filingStatus.getStatus());

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/ReaAcceptanceStrategyTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import uk.gov.companieshouse.filing.received.Transaction;
 import uk.gov.companieshouse.filingmock.model.FilingStatus;
@@ -24,49 +26,12 @@ class ReaAcceptanceStrategyTest {
         transaction = new Transaction();
     }
 
-    @Test
-    void acceptValidEmail() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "{\"registered_email_address\":\"info@acme.com\"}", "{}",
+            "{\"registered_email_address\":null}", "{\"registered_email_address\":\"\"}" })
+    void acceptValidEmailEmpty(String json) throws Exception {
         // GIVEN
-        transaction.setData("{\"registered_email_address\":\"info@acme.com\"}");
-
-        // WHEN
-        FilingStatus filingStatus = strategy.accept(transaction);
-
-        // THEN
-        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
-        assertNull(filingStatus.getRejection());
-    }
-
-    @Test
-    void acceptValidEmailMissing() throws Exception {
-        // GIVEN
-        transaction.setData("{}");
-
-        // WHEN
-        FilingStatus filingStatus = strategy.accept(transaction);
-
-        // THEN
-        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
-        assertNull(filingStatus.getRejection());
-    }
-
-    @Test
-    void acceptValidEmailNull() throws Exception {
-        // GIVEN
-        transaction.setData("{\"registered_email_address\":null}");
-
-        // WHEN
-        FilingStatus filingStatus = strategy.accept(transaction);
-
-        // THEN
-        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
-        assertNull(filingStatus.getRejection());
-    }
-
-    @Test
-    void acceptValidEmailEmpty() throws Exception {
-        // GIVEN
-        transaction.setData("{\"registered_email_address\":\"\"}");
+        transaction.setData(json);
 
         // WHEN
         FilingStatus filingStatus = strategy.accept(transaction);

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/RoaAcceptanceStrategyTest.java
@@ -12,7 +12,7 @@ import uk.gov.companieshouse.filing.received.Transaction;
 import uk.gov.companieshouse.filingmock.model.FilingStatus;
 import uk.gov.companieshouse.filingmock.model.Status;
 
-public class RoaAcceptanceStrategyTest {
+class RoaAcceptanceStrategyTest {
 
     private static final String ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
     private static final String WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
@@ -42,24 +42,24 @@ public class RoaAcceptanceStrategyTest {
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
     }
-    
+
     @Test
-    public void rejectChPostcodeWales() throws Exception {
+    void rejectChPostcodeWales() throws Exception {
         postCodeTest("cf14 3UZ");
     }
-    
+
     @Test
-    public void rejectChPostcodeEngland() throws Exception {
+    void rejectChPostcodeEngland() throws Exception {
         postCodeTest("SW1h  9EX");
     }
-    
+
     @Test
-    public void rejectChPostcodeNorthernIreland() throws Exception {
+    void rejectChPostcodeNorthernIreland() throws Exception {
         postCodeTest("BT2   8bg");
     }
-    
+
     @Test
-    public void rejectChPostcodeScotland() throws Exception {
+    void rejectChPostcodeScotland() throws Exception {
         postCodeTest("Eh39fF");
     }
 

--- a/src/test/java/uk/gov/companieshouse/filingmock/reader/FilingReaderImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/reader/FilingReaderImplTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.gov.companieshouse.filing.received.FilingReceived;
 import uk.gov.companieshouse.filing.received.SubmissionRecord;
-import uk.gov.companieshouse.filingmock.reader.FilingReaderImpl;
 import uk.gov.companieshouse.kafka.consumer.CHConsumer;
 import uk.gov.companieshouse.kafka.consumer.ConsumerConfig;
 import uk.gov.companieshouse.kafka.deserialization.AvroDeserializer;
@@ -32,7 +31,7 @@ import uk.gov.companieshouse.kafka.exceptions.DeserializationException;
 import uk.gov.companieshouse.kafka.message.Message;
 
 @ExtendWith(MockitoExtension.class)
-public class FilingReaderImplTest {
+class FilingReaderImplTest {
 
     @InjectMocks
     @Spy
@@ -48,7 +47,7 @@ public class FilingReaderImplTest {
     private AvroDeserializer<FilingReceived> deserializer;
     
     @Test
-    public void init() {
+    void init() {
         doReturn(consumer).when(reader).createConsumer(Mockito.any());
         reader.brokerAddress = "kafka address";
         reader.topicName = "filing-received";
@@ -73,7 +72,7 @@ public class FilingReaderImplTest {
     }
 
     @Test
-    public void readNoMessage() {
+    void readNoMessage() {
         List<Message> messages = Collections.emptyList();
         when(consumer.consume()).thenReturn(messages);
 
@@ -83,7 +82,7 @@ public class FilingReaderImplTest {
     }
 
     @Test
-    public void readValidMessages() throws Exception {
+    void readValidMessages() throws Exception {
         when(deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class)).thenReturn(deserializer);
 
         List<Message> messages = new ArrayList<>();
@@ -106,7 +105,7 @@ public class FilingReaderImplTest {
     }
 
     @Test
-    public void readInvalidMessage() throws Exception {
+    void readInvalidMessage() throws Exception {
         when(deserializerFactory.getSpecificRecordDeserializer(FilingReceived.class)).thenReturn(deserializer);
 
         List<Message> messages = new ArrayList<>();

--- a/src/test/java/uk/gov/companieshouse/filingmock/util/DateServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/util/DateServiceImplTest.java
@@ -5,15 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
-
-import uk.gov.companieshouse.filingmock.util.DateServiceImpl;
-
-public class DateServiceImplTest {
+ class DateServiceImplTest {
 
     private DateServiceImpl service = new DateServiceImpl();
 
     @Test
-    public void testNow() {
+    void testNow() {
         Instant before = Instant.now();
 
         Instant result = service.now();

--- a/src/test/java/uk/gov/companieshouse/filingmock/writer/FilingWriterImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/writer/FilingWriterImplTest.java
@@ -21,26 +21,26 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.filingmock.model.FilingProcessed;
 
 @ExtendWith(MockitoExtension.class)
-public class FilingWriterImplTest {
-    
+class FilingWriterImplTest {
+
     private static final String KAFKA_API_URL = "http://kafka-api-url:1234";
-    
+
     @InjectMocks
     private FilingWriterImpl writer;
-    
+
     @Mock
     private RestTemplate rest;
-    
+
     private FilingProcessed filingProcessed;
-    
+
     @BeforeEach
-    public void setup() {
+    void setup() {
         writer.kafkaApiUrl = KAFKA_API_URL;
         filingProcessed = new FilingProcessed();
     }
-    
+
     @Test
-    public void write() throws Exception {
+    void write() throws Exception {
         ResponseEntity<Object> response = new ResponseEntity<>(HttpStatus.CREATED);
         when(rest.postForEntity(eq(KAFKA_API_URL), eq(filingProcessed), any())).thenReturn(response);
         
@@ -48,17 +48,17 @@ public class FilingWriterImplTest {
         
         verify(rest).postForEntity(eq(KAFKA_API_URL), eq(filingProcessed), any());
     }
-    
+
     @Test
-    public void writeErrorResponse() throws Exception {
+    void writeErrorResponse() throws Exception {
         ResponseEntity<Object> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         when(rest.postForEntity(eq(KAFKA_API_URL), eq(filingProcessed), any())).thenReturn(response);
         
         assertThrows(FilingWriterException.class, () -> writer.write(filingProcessed));
     }
-    
+
     @Test
-    public void writeRestException() throws Exception {
+    void writeRestException() throws Exception {
         when(rest.postForEntity(eq(KAFKA_API_URL), eq(filingProcessed), any()))
                 .thenThrow(new RestClientException("exception"));
 


### PR DESCRIPTION
Remove 42 code smells flagged by Sonar:
- Remove unused imports
- Remove public modifiers from unit tests
- Use ParametrizedTest