### PR TITLE
Make more specific the handling of PSC cessations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It consumes [FilingReceived](https://github.com/companieshouse/chs-kafka-schemas
 The filing will automatically be accepted unless it matches one of the pre-determined reject criteria:
 - A change of address transaction using one of the Companies House's post codes (CF14 3UZ, BT28BG, SW1H9EX, EH39FF).
 - An insolvency transaction (the logic is looking for a submission kind containing the string 'insolvency') where the first practitioner associated with the insolvency case is using one of the Companies House's post codes (CF14 3UZ, BT28BG, SW1H9EX, EH39FF).
+- A PSC cessation transaction where the ceased date is either the 1st or 16th of a month.
 
 As new filings are exposed to external software vendors more reject criteria should be added to this list and the relevant public documentation. 
 

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
@@ -25,7 +25,7 @@ public class AcceptanceStrategyFactory {
             return REA;
         } else if (submissionType.contains("insolvency")) /* There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency," and should use the same strategy */ {
             return INSOLVENCY;
-        } else if ("psc-filing#cessation".equals(submissionType)) {
+        } else if (submissionType.startsWith("psc-filing#cessation")) {
             return PSC_CESSATION;
         }
 

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
@@ -8,7 +8,7 @@ public class AcceptanceStrategyFactory {
     private static final AcceptanceStrategy ROA = new RoaAcceptanceStrategy();
     private static final AcceptanceStrategy REA = new ReaAcceptanceStrategy();
     private static final AcceptanceStrategy INSOLVENCY = new InsolvencyAcceptanceStrategy();
-    private static final AcceptanceStrategy CESSATION = new PscAcceptanceStrategy();
+    private static final AcceptanceStrategy PSC_CESSATION = new PscCessationAcceptanceStrategy();
     private static final AcceptanceStrategy ALWAYS_ACCEPT = t -> new FilingStatus();
 
     private AcceptanceStrategyFactory() {
@@ -25,8 +25,8 @@ public class AcceptanceStrategyFactory {
             return REA;
         } else if (submissionType.contains("insolvency")) /* There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency," and should use the same strategy */ {
             return INSOLVENCY;
-        } else if (submissionType.contains("cessation")) {
-            return CESSATION;
+        } else if ("psc-filing#cessation".equals(submissionType)) {
+            return PSC_CESSATION;
         }
 
         return ALWAYS_ACCEPT;

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/PscCessationAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/PscCessationAcceptanceStrategy.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  *
  */
 @Component
-public class PscAcceptanceStrategy implements AcceptanceStrategy{
+public class PscCessationAcceptanceStrategy implements AcceptanceStrategy{
 
     private static final ObjectReader PSC_READER = new ObjectMapper()
             .registerModule(new JavaTimeModule())
@@ -35,7 +35,7 @@ public class PscAcceptanceStrategy implements AcceptanceStrategy{
     static final String INVALID_DATE_ENGLISH_REJECT = "You can not use the 1st or 16th of a month";
     static final String INVALID_DATE_WELSH_REJECT = "You can not use the 1st or 16th of a month";
 
-    PscAcceptanceStrategy() {
+    PscCessationAcceptanceStrategy() {
         // Private constructor
     }
 

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
@@ -23,9 +23,9 @@ class AcceptanceStrategyFactoryTest {
     @Test
     void getPscStrategy() {
         Transaction submission = new Transaction();
-        submission.setKind("cessation");
+        submission.setKind("psc-filing#cessation");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
-        assertTrue(strategy instanceof PscAcceptanceStrategy);
+        assertTrue(strategy instanceof PscCessationAcceptanceStrategy);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactoryTest.java
@@ -21,9 +21,9 @@ class AcceptanceStrategyFactoryTest {
     }
 
     @Test
-    void getPscStrategy() {
+    void getCessationIndividualPscStrategy() {
         Transaction submission = new Transaction();
-        submission.setKind("psc-filing#cessation");
+        submission.setKind("psc-filing#cessation#individual");
         AcceptanceStrategy strategy = AcceptanceStrategyFactory.getStrategy(submission);
         assertTrue(strategy instanceof PscCessationAcceptanceStrategy);
     }

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/PscCessationAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/PscCessationAcceptanceStrategyTest.java
@@ -11,17 +11,17 @@ import uk.gov.companieshouse.filingmock.model.Status;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static uk.gov.companieshouse.filingmock.processor.strategy.PscAcceptanceStrategy.INVALID_DATE_ENGLISH_REJECT;
-import static uk.gov.companieshouse.filingmock.processor.strategy.PscAcceptanceStrategy.INVALID_DATE_WELSH_REJECT;
+import static uk.gov.companieshouse.filingmock.processor.strategy.PscCessationAcceptanceStrategy.INVALID_DATE_ENGLISH_REJECT;
+import static uk.gov.companieshouse.filingmock.processor.strategy.PscCessationAcceptanceStrategy.INVALID_DATE_WELSH_REJECT;
 
-class PscAcceptanceStrategyTest {
-    private PscAcceptanceStrategy strategy;
+class PscCessationAcceptanceStrategyTest {
+    private PscCessationAcceptanceStrategy strategy;
 
     private Transaction transaction;
 
     @BeforeEach
     void setUp() {
-        strategy = new PscAcceptanceStrategy();
+        strategy = new PscCessationAcceptanceStrategy();
         transaction = new Transaction();
     }
 


### PR DESCRIPTION
This is just a tidy up to make more specific and clear that cessations refer to PSC filings. As it stands it can clash with future cessation filings.

- Use the full submission type to determine the PSC cessation strategy
- Rename acceptance strategy to include "cessation" - it is not just a PSC acceptance strategy
- Add note to the readme

See https://github.com/companieshouse/chips-filing-mock/pull/31