### PR TITLE
Move duplicated logic to abstract parent class

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioner.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioner.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.filingmock.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// although this wraps only address currently, it could be expanded to cover other fields - hence the generic name
+public class InsolvencyPractitioner {
+    // note that existing Address class was used for ROA, but ROA used snake_case in Kafka whereas Insolvency API is using PascalCase
+    @JsonProperty("Address")
+    IPAddressTruncated address;
+    
+    public String getPostalCode() {
+        return address.getPostalCode();
+    }
+}
+
+class IPAddressTruncated {
+    @JsonProperty("PostalCode")
+    private String postalCode;
+
+    String getPostalCode() {
+        return postalCode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioners.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/model/InsolvencyPractitioners.java
@@ -11,31 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class InsolvencyPractitioners {
     
     @JsonProperty("practitioners")
-    private List<PractitionerWrapper> practitioners;
+    private List<InsolvencyPractitioner> practitioners;
 
-
-    public String getPractitionerOnePostcode() {
-        if (practitioners == null || practitioners.isEmpty()) {
-            return null;
-        }
-        return practitioners.get(0).address.getPostalCode();
+    public List<InsolvencyPractitioner> getPractitioners() {
+        return practitioners;
     }
-
-}
-
-// although this wraps only address currently, it could be expanded to cover other fields - hence the generic name
-class PractitionerWrapper {
-    // note that existing Address class was used for ROA, but ROA used snake_case in Kafka whereas Insolvency API is using PascalCase
-    @JsonProperty("Address")
-    IPAddressTruncated address;
-}
-
-class IPAddressTruncated {
-    @JsonProperty("PostalCode")
-    private String postalCode;
-
-    public String getPostalCode() {
-        return postalCode;
-    }
-
 }

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategy.java
@@ -1,46 +1,37 @@
 package uk.gov.companieshouse.filingmock.processor.strategy;
 
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.filing.received.Transaction;
-import uk.gov.companieshouse.filingmock.model.FilingStatus;
-import uk.gov.companieshouse.filingmock.model.InsolvencyPractitioners;
-import uk.gov.companieshouse.filingmock.model.Status;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
+import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filingmock.model.InsolvencyPractitioners;
 
 /**
- * Rejects the filing only if the provided address uses Companies House postcode
+ * Rejects the filing only if the first practitioner's address uses Companies House postcode
  *
  */
 @Component
-public class InsolvencyAcceptanceStrategy implements AcceptanceStrategy {
+public class InsolvencyAcceptanceStrategy extends PostCodeNotCHAcceptanceStrategy {
     private static final ObjectReader PRACTITIONERS_READER = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).readerFor(InsolvencyPractitioners.class);
-
-    private static final List<String> CH_POSTCODE = Arrays.asList("CF143UZ","BT28BG","SW1H9EX","EH39FF");
-    private static final String CH_POSTCODE_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
-    private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
 
     InsolvencyAcceptanceStrategy() {
         // Private constructor
     }
 
     @Override
-    public FilingStatus accept(Transaction transaction) throws AcceptanceStrategyException {
-        FilingStatus filingStatus = new FilingStatus();
-
+    protected boolean containsCompaniesHousePostcode(Transaction transaction) throws AcceptanceStrategyException {
         InsolvencyPractitioners practitioners = getPractitioners(transaction);
-        if (!practitionerOneHasValidPostcode(practitioners)) {
-            filingStatus.setStatus(Status.REJECTED);
-            filingStatus.addRejection(CH_POSTCODE_ENGLISH_REJECT, CH_POSTCODE_WELSH_REJECT);
+        String postCode = null;
+        if (practitioners != null && practitioners.getPractitioners() != null && !practitioners.getPractitioners().isEmpty()) {
+            postCode = practitioners.getPractitioners().get(0).getPostalCode();
         }
-
-        return filingStatus;
+        return isCHPostCode(postCode);
     }
 
     private InsolvencyPractitioners getPractitioners(Transaction transaction) throws AcceptanceStrategyException {
@@ -50,19 +41,4 @@ public class InsolvencyAcceptanceStrategy implements AcceptanceStrategy {
             throw new AcceptanceStrategyException(e);
         }
     }
-
-    /**
-     * An address is always valid unless it uses Companies House's post code
-     * 
-     * @param practitioners all insolvency practitioners extracted from transaction
-     * @return a boolean representing whether address uses CH post code
-     */
-    private boolean practitionerOneHasValidPostcode(InsolvencyPractitioners practitioners) {
-        if(practitioners.getPractitionerOnePostcode() != null) {
-            return !CH_POSTCODE.contains(practitioners.getPractitionerOnePostcode().toUpperCase().replaceAll("\\s", ""));
-        }
-
-        return true;
-    }
-
 }

--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/PostCodeNotCHAcceptanceStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/PostCodeNotCHAcceptanceStrategy.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.filingmock.processor.strategy;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import uk.gov.companieshouse.filing.received.Transaction;
+import uk.gov.companieshouse.filingmock.model.FilingStatus;
+import uk.gov.companieshouse.filingmock.model.Status;
+
+/**
+ * Rejects the filing if it uses any Companies House postcode
+ *
+ */
+abstract class PostCodeNotCHAcceptanceStrategy implements AcceptanceStrategy {
+    private static final List<String> CH_POSTCODE = Arrays.asList("CF143UZ","BT28BG","SW1H9EX","EH39FF");
+    private static final String CH_POSTCODE_ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
+    private static final String CH_POSTCODE_WELSH_REJECT = "Ni all y cod post rydych wedi'i gyflenwi fod yn god post Tŷ'r Cwmnïau";
+
+    @Override
+    public FilingStatus accept(Transaction transaction) throws AcceptanceStrategyException {
+        FilingStatus filingStatus = new FilingStatus();
+
+        if (containsCompaniesHousePostcode(transaction)) {
+            filingStatus.setStatus(Status.REJECTED);
+            filingStatus.addRejection(CH_POSTCODE_ENGLISH_REJECT, CH_POSTCODE_WELSH_REJECT);
+        }
+
+        return filingStatus;
+    }
+    
+    protected abstract boolean containsCompaniesHousePostcode(Transaction transaction) throws AcceptanceStrategyException;
+
+    protected boolean isCHPostCode(String postCode) {
+        return !StringUtils.isEmpty(postCode)
+                && CH_POSTCODE.contains(postCode.toUpperCase().replaceAll("\\s", ""));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/filingmock/processor/strategy/InsolvencyAcceptanceStrategyTest.java
@@ -8,6 +8,9 @@ import uk.gov.companieshouse.filingmock.model.Status;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 class InsolvencyAcceptanceStrategyTest {
 
     private static final String ENGLISH_REJECT = "The postcode you have supplied cannot be Companies House postcode";
@@ -24,43 +27,65 @@ class InsolvencyAcceptanceStrategyTest {
     }
 
     @Test
-    void acceptValidPostcode() throws Exception {
-        transaction.setData("{\"practitioners\":[{\"Address\":{\"PostalCode\":\" M8 8EQ \"}}]}");
+    void acceptValidFirstPostcode() throws Exception {
+        transaction.setData(createData(" M8 8EQ ", "CF143UZ"));
         FilingStatus filingStatus = strategy.accept(transaction);
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
     }
 
     @Test
-    void acceptNoPostcode() throws Exception {
+    void acceptNoPractitioners() throws Exception {
         transaction.setData("{}");
         FilingStatus filingStatus = strategy.accept(transaction);
         assertEquals(Status.ACCEPTED, filingStatus.getStatus());
         assertNull(filingStatus.getRejection());
     }
-    
+
     @Test
-    void rejectChPostcodeWales() throws Exception {
-        postCodeTest("cf14 3UZ");
-    }
-    
-    @Test
-    void rejectChPostcodeEngland() throws Exception {
-        postCodeTest("Sw1H   9EX");
-    }
-    
-    @Test
-    void rejectChPostcodeNorthernIreland() throws Exception {
-        postCodeTest("BT2   8bg");
-    }
-    
-    @Test
-    void rejectChPostcodeScotland() throws Exception {
-        postCodeTest("Eh39fF");
+    void acceptEmptyPractitioners() throws Exception {
+        transaction.setData("{\"practitioners\":[]}");
+        FilingStatus filingStatus = strategy.accept(transaction);
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
     }
 
-    private void postCodeTest(String postCode) throws Exception {
-        transaction.setData("{\"practitioners\":[{\"Address\":{\"PostalCode\":\"" + postCode + "\"}}]}");
+    @Test
+    void acceptFirstPractitionerNoPostcode() throws Exception {
+        transaction.setData("{\"practitioners\":[{\"Address\":{}}]}");
+        FilingStatus filingStatus = strategy.accept(transaction);
+        assertEquals(Status.ACCEPTED, filingStatus.getStatus());
+        assertNull(filingStatus.getRejection());
+    }
+
+    @Test
+    void rejectChPostcodeWales() throws Exception {
+        postCodeTest("cf14 3UZ", "M8 8EQ");
+    }
+
+    @Test
+    void rejectChPostcodeEngland() throws Exception {
+        postCodeTest("Sw1H   9EX", "AA");
+    }
+
+    @Test
+    void rejectChPostcodeNorthernIreland() throws Exception {
+        postCodeTest("BT2   8bg", "CF144UZ");
+    }
+
+    @Test
+    void rejectChPostcodeScotland() throws Exception {
+        postCodeTest("Eh39fF", "Eh39AF");
+    }
+
+    @Test
+    void throwsExceptionInvalidData() {
+        transaction.setData("invalid");
+        assertThrows(AcceptanceStrategyException.class, () -> strategy.accept(transaction));
+    }
+
+    private void postCodeTest(String... postCode) throws Exception {
+        transaction.setData(createData(postCode));
         FilingStatus filingStatus = strategy.accept(transaction);
         assertEquals(Status.REJECTED, filingStatus.getStatus());
         assertEquals(1, filingStatus.getRejection().getEnglishReasons().size());
@@ -70,10 +95,13 @@ class InsolvencyAcceptanceStrategyTest {
         
     }
 
-    @Test
-    void throwsExceptionInvalidData() {
-        transaction.setData("invalid");
-        assertThrows(AcceptanceStrategyException.class, () -> strategy.accept(transaction));
+    private String createData(String... postCodes) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"practitioners\":[");
+        sb.append(Stream.of(postCodes).map(p -> "{\"Address\":{\"PostalCode\":\"" + p + "\"}}")
+                .collect(Collectors.joining(", ")));
+        sb.append("]}");
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
Logic to determine if a post code belongs to Companies House is used by two different strategies: ROA and insolvency
Move this duplicated code to a parent strategy class