### PR TITLE
Use startsWith instead of contains

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/processor/strategy/AcceptanceStrategyFactory.java
@@ -23,7 +23,8 @@ public class AcceptanceStrategyFactory {
             return ROA;
         } else if ("registered-email-address".equals(submissionType)) {
             return REA;
-        } else if (submissionType.contains("insolvency")) /* There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency," and should use the same strategy */ {
+        } else if (submissionType.startsWith("insolvency")) {
+            /* There are multiple insolvency types e.g. insolvency#600 but all will start with "insolvency" and should use the same strategy */
             return INSOLVENCY;
         } else if (submissionType.contains("cessation")) {
             return CESSATION;


### PR DESCRIPTION
Insolvency submissions have "insolvency" as the type, followed by a subtypes, eg `insolvency#600`
The AcceptanceStrategyFactory is looking for "insolvency" in any part of the filing submission type but should only check the first part of it. 
Using `startsWith` over `contains` should also increase performance