### PR TITLE
updated cidev vars for testing purposes

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,10 +4,13 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 
-# for testing purposes set desired_task_count = 1, and service_autoscale_enabled = true
+# for testing purposes set desired_task_count = 1
 # set to 0 during normal service, due to acceptance emails sent and transactions marked as accepted in CHS before being processed in Chips.
-desired_task_count = 0
+# or scale down manually in aws after testing complete.
+desired_task_count = 1
 
 service_autoscale_enabled  = false
+# If no manual scale down done, this will scale down every night. To re-enable, trigger pipeline apply again
 service_scaledown_schedule = "55 19 * * ? *"
-service_scaleup_schedule   = "5 6 * * ? *"
+# Stop service redeployment after a manual scale down.
+service_scaleup_schedule   = ""


### PR DESCRIPTION
Service currently does not scale up on pipeline apply in cidev. Attempts to manually update the service appears to have issues. 
This change should in cidev
1. deploy from pipeline
2. After testing either manual scale down or scheduled scale down should bring it down
3. A further on demand scale up should happen and not a scheduled scale up.