### PR TITLE
Migrate chips-filing-mock to Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  
   <modelVersion>4.0.0</modelVersion>
+  
   <artifactId>chips-filing-mock</artifactId>
   <packaging>jar</packaging>
   <version>unversioned</version>
@@ -16,23 +18,19 @@
     <version>2.1.12</version>
     <relativePath/>
   </parent>
-
+  
   <properties>
     <java.version>21</java.version>
     <ch-kafka.version>3.0.6</ch-kafka.version>
     <kafka-models.version>3.0.31</kafka-models.version>
     <structured-logging.version>3.0.54</structured-logging.version>
-    <jai_core.version>1.1.3</jai_core.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <avro.version>1.12.1</avro.version>
     <spring-boot-starter.version>4.0.6</spring-boot-starter.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>
     <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
 
     <!-- Overrides -->
-    <!-- CVE-2025-48924 -->
-    <commons-lang3.version>3.18.0</commons-lang3.version>
     <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
 
     <!-- Sonar Config -->
@@ -41,15 +39,6 @@
     <sonar.password></sonar.password>
     <sonar.projectName>chips-filing-mock</sonar.projectName>
     <sonar.projectKey>uk.gov.companieshouse:chips-filing-mock</sonar.projectKey>
-
-    <assertj-core.version>3.27.7</assertj-core.version>
-    <log4j-api.version>2.25.4</log4j-api.version>
-    <logback-core.version>1.5.28</logback-core.version>
-    <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
-    <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
-    <jetty-server.version>12.1.7</jetty-server.version>
-    <kotlin.version>2.2.21</kotlin.version>
-    <plexus.version>4.0.3</plexus.version>
   </properties>
 
   <dependencyManagement>
@@ -61,166 +50,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${assertj-core.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j-api.version}</version>
-        <scope>compile</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang3.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback-core.version}</version>
-        <scope>compile</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${tomcat-embed-core.version}</version>
-        <scope>compile</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${tomcat-embed-websocket.version}</version>
-        <scope>compile</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-http</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-io</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-xml</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-client</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-alpn-client</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-session</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-security</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-webapp</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-servlet</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-ee</artifactId>
-        <version>${jetty-server.version}</version>
-        <scope>compile</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk7</artifactId>
-        <version>${kotlin.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <!-- CVE-2025-67030 -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>${plexus.version}</version>
-        <scope>compile</scope>
-      </dependency>
     </dependencies>
 
   </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -229,10 +70,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-restclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.minidev</groupId>
-      <artifactId>json-smart</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -258,22 +95,17 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
- 
+    
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
-
+ 
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${kafka-clients.version}</version>
       <exclusions>
         <exclusion>
             <groupId>org.lz4</groupId>
@@ -296,33 +128,6 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
       <version>${structured-logging.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.media</groupId>
-      <artifactId>jai_core</artifactId>
-      <version>${jai_core.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonarsource.scanner.maven</groupId>
-      <artifactId>sonar-maven-plugin</artifactId>
-      <version>${sonar-maven-plugin.version}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,9 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <avro.version>1.12.1</avro.version>
-    <spring-boot-starter.version>3.5.14</spring-boot-starter.version>
+    <spring-boot-starter.version>4.0.6</spring-boot-starter.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>
     <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
-    <json-smart.version>2.5.2</json-smart.version>
-    <opentelemetry-instrumentation-bom.version>2.14.0</opentelemetry-instrumentation-bom.version>
 
     <!-- Overrides -->
     <!-- CVE-2025-48924 -->
@@ -50,21 +48,12 @@
     <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
     <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
     <jetty-server.version>12.1.7</jetty-server.version>
-    <jackson-core.version>2.21.1</jackson-core.version>
-    <jackson-annotations.version>2.21</jackson-annotations.version>
     <kotlin.version>2.2.21</kotlin.version>
     <plexus.version>4.0.3</plexus.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.opentelemetry.instrumentation</groupId>
-        <artifactId>opentelemetry-instrumentation-bom</artifactId>
-        <version>${opentelemetry-instrumentation-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -218,16 +207,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-spring-boot-starter</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -244,21 +223,26 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>${json-smart.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring-boot-starter.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-logging</artifactId>
-      <version>${spring-boot-starter.version}</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>
@@ -277,9 +261,8 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.7</version>
     </dependency>
-
+ 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
@@ -330,12 +313,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson-annotations.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
 
     <!-- Overrides -->
-    <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
+    <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 
     <!-- Sonar Config -->
     <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-    </dependencies>
+      <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-instrumentation-bom</artifactId>
+        <version>2.26.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+     </dependency>
+   </dependencies>
 
   </dependencyManagement>
 
@@ -66,6 +73,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+        <version>2.26.1-alpha</version>
+        <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -130,6 +143,10 @@
       <version>${structured-logging.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <groupId>io.opentelemetry.instrumentation</groupId>
         <artifactId>opentelemetry-logback-appender-1.0</artifactId>
         <version>2.26.1-alpha</version>
-        <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/companieshouse/filingmock/Config.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/Config.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.filingmock;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.filingmock;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+
+@Component
+class OpenTelemetryAppenderInitializer implements InitializingBean {
+    private final OpenTelemetry openTelemetry;
+    
+    OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+    
+    @Override
+    public void afterPropertiesSet() {
+        OpenTelemetryAppender.install(this.openTelemetry);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,8 @@ management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/chips-filing-mock
 management.endpoints.web.path-mapping.health=/healthcheck
 management.endpoint.health.enabled=true
+
+# OpenTelemetry configuration
+management.opentelemetry.logging.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces
+management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ kafka.consumer.pollTimeout=${KAFKA_CONSUMER_TIMEOUT_MS}
 
 kafka.api.url=${CHS_KAFKA_API_LOCAL_URL}/private/filing-processed
 
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=none
 management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/chips-filing-mock
 management.endpoints.web.path-mapping.health=/healthcheck


### PR DESCRIPTION
Migrate chips-filing-mock to Spring Boot 4

Maven full build OK including unit tests passed, smoke test in chs-dev is OK

Also, update version of the sonar-maven-plugin to clear CVE [GHSA-574f-3g2m-x479](https://dependency-track.companieshouse.gov.uk/vulnerabilities/GITHUB/GHSA-574f-3g2m-x479) on [bcprov-jdk18on](https://dependency-track.companieshouse.gov.uk/components/1450c097-cb95-4c74-b189-c0950314c3b4)