### PR TITLE
Feature/asm 2387 migrate to spring boot 4 ver2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,17 +248,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-logging</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-to-slf4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <scope>runtime</scope>
       <optional>true</optional>
@@ -290,6 +279,12 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>structured-logging</artifactId>
       <version>${structured-logging.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
 
     <assertj-core.version>3.27.7</assertj-core.version>
     <log4j-api.version>2.25.4</log4j-api.version>
-    <logback-core.version>1.5.28</logback-core.version>
     <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
     <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
     <jetty-server.version>12.1.7</jetty-server.version>
@@ -89,13 +88,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback-core.version}</version>
-        <scope>compile</scope>
       </dependency>
 
       <dependency>
@@ -259,14 +251,6 @@
       <artifactId>spring-boot-starter-logging</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-core</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-to-slf4j</artifactId>
         </exclusion>
@@ -331,11 +315,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -256,10 +256,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
     <!-- Overrides -->
     <!-- CVE-2025-48924 -->
     <commons-lang3.version>3.18.0</commons-lang3.version>
-    <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
+    
+    <!-- CVE-2025-14813 -->
+    <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 
     <!-- Sonar Config -->
     <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,9 @@
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <avro.version>1.12.1</avro.version>
-    <spring-boot-starter.version>3.5.14</spring-boot-starter.version>
+    <spring-boot-starter.version>4.0.6</spring-boot-starter.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>
     <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
-    <json-smart.version>2.5.2</json-smart.version>
-    <opentelemetry-instrumentation-bom.version>2.28.1</opentelemetry-instrumentation-bom.version>
 
     <!-- Overrides -->
     <!-- CVE-2025-48924 -->
@@ -50,8 +48,6 @@
     <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
     <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
     <jetty-server.version>12.1.7</jetty-server.version>
-    <jackson-core.version>2.21.1</jackson-core.version>
-    <jackson-annotations.version>2.21</jackson-annotations.version>
     <kotlin.version>2.2.21</kotlin.version>
     <plexus.version>4.0.3</plexus.version>
   </properties>
@@ -61,10 +57,10 @@
       <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
         <artifactId>opentelemetry-instrumentation-bom</artifactId>
-        <version>${opentelemetry-instrumentation-bom.version}</version>
+        <version>2.26.1</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
+     </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -218,16 +214,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-spring-boot-starter</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -241,24 +227,34 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot-starter-webmvc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-logback-appender-1.0</artifactId>
+        <version>2.26.1-alpha</version>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>${json-smart.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${spring-boot-starter.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-logging</artifactId>
-      <version>${spring-boot-starter.version}</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>
@@ -277,7 +273,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.7</version>
     </dependency>
 
     <dependency>
@@ -330,12 +325,15 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson-annotations.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
     </dependency>
 
     <dependency>
@@ -343,7 +341,6 @@
       <artifactId>sonar-maven-plugin</artifactId>
       <version>${sonar-maven-plugin.version}</version>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/companieshouse/filingmock/Config.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/Config.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.filingmock;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.filingmock;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+class OpenTelemetryAppenderInitializer implements InitializingBean {
+
+    private final OpenTelemetry openTelemetry;
+
+    OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        OpenTelemetryAppender.install(this.openTelemetry);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
+++ b/src/main/java/uk/gov/companieshouse/filingmock/OpenTelemetryAppenderInitializer.java
@@ -7,11 +7,11 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 
 @Component
-class OpenTelemetryAppenderInitializer implements InitializingBean {
+public class OpenTelemetryAppenderInitializer implements InitializingBean {
 
     private final OpenTelemetry openTelemetry;
 
-    OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
+    public OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,13 @@ kafka.consumer.pollTimeout=${KAFKA_CONSUMER_TIMEOUT_MS}
 
 kafka.api.url=${CHS_KAFKA_API_LOCAL_URL}/private/filing-processed
 
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=none
 management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/chips-filing-mock
 management.endpoints.web.path-mapping.health=/healthcheck
 management.endpoint.health.enabled=true
+
+# OpenTelemetry configuration
+management.opentelemetry.logging.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs
+management.opentelemetry.tracing.export.otlp.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces
+management.otlp.metrics.export.url=${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@ kafka.consumer.pollTimeout=${KAFKA_CONSUMER_TIMEOUT_MS}
 kafka.api.url=${CHS_KAFKA_API_LOCAL_URL}/private/filing-processed
 
 management.endpoints.access.default=none
+management.endpoint.health.access=unrestricted
 management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/chips-filing-mock
 management.endpoints.web.path-mapping.health=/healthcheck

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,6 @@ kafka.consumer.pollTimeout=${KAFKA_CONSUMER_TIMEOUT_MS}
 kafka.api.url=${CHS_KAFKA_API_LOCAL_URL}/private/filing-processed
 
 management.endpoints.access.default=none
-management.endpoint.health.access=unrestricted
 management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/chips-filing-mock
 management.endpoints.web.path-mapping.health=/healthcheck


### PR DESCRIPTION
Migrate chips-filing-mock to Spring Boot 4

Maven full build OK including unit tests passed, smoke test in chs-dev is OK

Also, update version of the sonar-maven-plugin to clear CVE [GHSA-574f-3g2m-x479](https://dependency-track.companieshouse.gov.uk/vulnerabilities/GITHUB/GHSA-574f-3g2m-x479) on [bcprov-jdk18on](https://dependency-track.companieshouse.gov.uk/components/1450c097-cb95-4c74-b189-c0950314c3b4)

Note jackson, json-smart, slf4j versions had override warnings so they have been removed.

Simplified PR to minimal changes although there appear to be many dependency entries in the POM which are not required, e.g. Kotlin (!), JAI (!), tomcat (SpringBoot), jetty (SpringBoot), etc.